### PR TITLE
Add ping level to cars

### DIFF
--- a/src/constants/matchmaking-constants.ts
+++ b/src/constants/matchmaking-constants.ts
@@ -1,3 +1,4 @@
 export const MATCH_ATTRIBUTES = {
   mode: "battle",
 };
+export const PING_INTERVAL_MILLISECONDS = 1000;

--- a/src/enums/webrtc-type.ts
+++ b/src/enums/webrtc-type.ts
@@ -7,4 +7,6 @@ export enum WebRTCType {
   ObjectData,
   EventData,
   GracefulDisconnect,
+  PingRequest,
+  PingResponse,
 }

--- a/src/interfaces/webrtc-peer.ts
+++ b/src/interfaces/webrtc-peer.ts
@@ -4,6 +4,7 @@ import { ConnectionStateType } from "../enums/connection-state-type.js";
 export interface WebRTCPeer {
   getConnectionState(): ConnectionStateType;
   getToken(): string;
+  getPingTime(): number;
   getName(): string;
   getPlayer(): GamePlayer | null;
   setPlayer(player: GamePlayer): void;
@@ -17,6 +18,8 @@ export interface WebRTCPeer {
   ): Promise<RTCSessionDescriptionInit>;
   connect(answer: RTCSessionDescriptionInit): Promise<void>;
   addRemoteIceCandidate(iceCandidate: RTCIceCandidateInit): void;
+  mustPing(): boolean;
+  sendPingRequest(): void;
   sendReliableOrderedMessage(
     arrayBuffer: ArrayBuffer,
     skipQueue?: boolean

--- a/src/models/game-controller.ts
+++ b/src/models/game-controller.ts
@@ -2,6 +2,7 @@ import { GAME_VERSION } from "../constants/game-constants.js";
 import { APIService } from "../services/api-service.js";
 import { CryptoService } from "../services/crypto-service.js";
 import { EventProcessorService } from "../services/event-processor-service.js";
+import { IntervalService } from "../services/interval-service.js";
 import { MatchmakingService } from "../services/matchmaking-service.js";
 import { ObjectOrchestrator } from "../services/object-orchestrator-service.js";
 import { ScreenTransitionService } from "../services/screen-transition-service.js";
@@ -20,6 +21,7 @@ export class GameController {
   private gameKeyboard: GameKeyboard;
 
   private timers: TimerService[] = [];
+  private intervals: IntervalService[] = [];
 
   private readonly transitionService: ScreenTransitionService;
   private readonly apiService: APIService;
@@ -118,6 +120,39 @@ export class GameController {
     }
 
     console.log("Removed timer, updated timers count", this.timers.length);
+  }
+
+  public getIntervals(): IntervalService[] {
+    return this.intervals;
+  }
+
+  public addInterval(
+    seconds: number,
+    callback: () => void,
+    start = true
+  ): IntervalService {
+    const intervalService = new IntervalService(seconds, callback, start);
+    this.intervals.push(intervalService);
+
+    console.log(
+      "Added interval, updated intervals count",
+      this.intervals.length
+    );
+
+    return intervalService;
+  }
+
+  public removeInterval(interval: IntervalService): void {
+    const index = this.intervals.indexOf(interval);
+
+    if (index !== -1) {
+      this.intervals.splice(index, 1);
+    }
+
+    console.log(
+      "Removed interval, updated intervals count",
+      this.intervals.length
+    );
   }
 
   public getTransitionService(): ScreenTransitionService {

--- a/src/models/game-player.ts
+++ b/src/models/game-player.ts
@@ -1,6 +1,7 @@
 export class GamePlayer {
   private id: string;
   private host: boolean;
+  private pingTime: number = 0;
   private name: string;
   private score: number;
 
@@ -26,6 +27,14 @@ export class GamePlayer {
 
   public setHost(host: boolean): void {
     this.host = host;
+  }
+
+  public getPingTime(): number {
+    return this.pingTime;
+  }
+
+  public setPingTime(pingTime: number): void {
+    this.pingTime = pingTime;
   }
 
   public getName(): string {

--- a/src/objects/car-object.ts
+++ b/src/objects/car-object.ts
@@ -24,8 +24,13 @@ export class CarObject extends BaseDynamicCollidableGameObject {
   private readonly DISTANCE_CENTER: number = 220;
   private readonly FRICTION: number = 0.2;
 
-  private PLAYER_NAME_PADDING = 10;
-  private PLAYER_NAME_RECT_HEIGHT = 24;
+  private readonly PLAYER_NAME_PADDING = 10;
+  private readonly PLAYER_NAME_RECT_HEIGHT = 24;
+
+  private readonly PING_CIRCLE_RADIUS = 4;
+  private readonly PING_CIRCLE_SPACING = 4;
+  private readonly PING_ACTIVE_COLOR = "#00FF00";
+  private readonly PING_INACTIVE_COLOR = "#FF0000";
 
   private carImage: HTMLImageElement | null = null;
   private imagePath = this.IMAGE_BLUE_PATH;
@@ -98,6 +103,7 @@ export class CarObject extends BaseDynamicCollidableGameObject {
 
     context.restore();
 
+    this.renderPingLevel(context);
     this.renderPlayerName(context);
 
     // Hitbox debug
@@ -175,6 +181,43 @@ export class CarObject extends BaseDynamicCollidableGameObject {
 
   public override mustSync(): boolean {
     return this.speed !== 0;
+  }
+
+  private renderPingLevel(context: CanvasRenderingContext2D): void {
+    const pingTime = this.owner?.getPingTime() ?? 0;
+
+    // Determine the number of active circles based on ping
+    let activeCircles = 3; // Default to all green circles
+
+    if (pingTime > 400) {
+      activeCircles = 1;
+    } else if (pingTime > 200) {
+      activeCircles = 2;
+    }
+
+    // Calculate starting position for circles
+    const totalWidth =
+      3 * (2 * this.PING_CIRCLE_RADIUS) + 2 * this.PING_CIRCLE_SPACING;
+    const startX = this.x + this.WIDTH / 2 - totalWidth / 2 + 4;
+    const startY = this.y - this.PLAYER_NAME_RECT_HEIGHT - 15;
+
+    // Draw the circles
+    context.save();
+
+    for (let i = 0; i < 3; i++) {
+      const x =
+        startX + i * (2 * this.PING_CIRCLE_RADIUS + this.PING_CIRCLE_SPACING);
+      const color =
+        i < activeCircles ? this.PING_ACTIVE_COLOR : this.PING_INACTIVE_COLOR;
+
+      context.beginPath();
+      context.arc(x, startY, this.PING_CIRCLE_RADIUS, 0, Math.PI * 2);
+      context.fillStyle = color;
+      context.fill();
+      context.closePath();
+    }
+
+    context.restore();
   }
 
   private renderPlayerName(context: CanvasRenderingContext2D): void {

--- a/src/objects/car-object.ts
+++ b/src/objects/car-object.ts
@@ -6,8 +6,6 @@ import {
   BLUE_TEAM_TRANSPARENCY_COLOR,
   RED_TEAM_TRANSPARENCY_COLOR,
 } from "../constants/colors-constants.js";
-import { PlayerUtils } from "../utils/player-utils.js";
-import { DebugUtils } from "../utils/debug-utils.js";
 
 export class CarObject extends BaseDynamicCollidableGameObject {
   protected readonly TOP_SPEED: number = 4;
@@ -102,10 +100,6 @@ export class CarObject extends BaseDynamicCollidableGameObject {
 
     this.renderPlayerName(context);
 
-    if (this.debug) {
-      this.renderDebugInformation(context);
-    }
-
     // Hitbox debug
     super.render(context);
   }
@@ -188,8 +182,6 @@ export class CarObject extends BaseDynamicCollidableGameObject {
 
     // Retrieve the player's name or a default value
     const playerName = this.owner?.getName() ?? "Unknown";
-    const playerPing = this.owner?.getPingTime() ?? 0;
-    const playerPingColor = PlayerUtils.getColorByPingTime(playerPing);
 
     // Set font for measurement and rendering
     context.font = "16px system-ui";
@@ -256,7 +248,7 @@ export class CarObject extends BaseDynamicCollidableGameObject {
     context.fill();
 
     // Set fill style for the text
-    context.fillStyle = playerPingColor;
+    context.fillStyle = "white";
     context.textAlign = "center";
     context.textBaseline = "middle";
 
@@ -268,14 +260,5 @@ export class CarObject extends BaseDynamicCollidableGameObject {
     );
 
     context.restore();
-  }
-
-  protected renderDebugInformation(context: CanvasRenderingContext2D): void {
-    this.renderDebugPingInformation(context);
-  }
-
-  private renderDebugPingInformation(context: CanvasRenderingContext2D): void {
-    const pingTime = this.owner?.getPingTime().toFixed(0) ?? 0;
-    DebugUtils.renderDebugText(context, `Ping: ${pingTime} ms`, 24, 72, 100);
   }
 }

--- a/src/objects/car-object.ts
+++ b/src/objects/car-object.ts
@@ -6,6 +6,8 @@ import {
   BLUE_TEAM_TRANSPARENCY_COLOR,
   RED_TEAM_TRANSPARENCY_COLOR,
 } from "../constants/colors-constants.js";
+import { PlayerUtils } from "../utils/player-utils.js";
+import { DebugUtils } from "../utils/debug-utils.js";
 
 export class CarObject extends BaseDynamicCollidableGameObject {
   protected readonly TOP_SPEED: number = 4;
@@ -100,6 +102,10 @@ export class CarObject extends BaseDynamicCollidableGameObject {
 
     this.renderPlayerName(context);
 
+    if (this.debug) {
+      this.renderDebugInformation(context);
+    }
+
     // Hitbox debug
     super.render(context);
   }
@@ -182,6 +188,8 @@ export class CarObject extends BaseDynamicCollidableGameObject {
 
     // Retrieve the player's name or a default value
     const playerName = this.owner?.getName() ?? "Unknown";
+    const playerPing = this.owner?.getPingTime() ?? 0;
+    const playerPingColor = PlayerUtils.getColorByPingTime(playerPing);
 
     // Set font for measurement and rendering
     context.font = "16px system-ui";
@@ -248,7 +256,7 @@ export class CarObject extends BaseDynamicCollidableGameObject {
     context.fill();
 
     // Set fill style for the text
-    context.fillStyle = "white";
+    context.fillStyle = playerPingColor;
     context.textAlign = "center";
     context.textBaseline = "middle";
 
@@ -260,5 +268,14 @@ export class CarObject extends BaseDynamicCollidableGameObject {
     );
 
     context.restore();
+  }
+
+  protected renderDebugInformation(context: CanvasRenderingContext2D): void {
+    this.renderDebugPingInformation(context);
+  }
+
+  private renderDebugPingInformation(context: CanvasRenderingContext2D): void {
+    const pingTime = this.owner?.getPingTime().toFixed(0) ?? 0;
+    DebugUtils.renderDebugText(context, `Ping: ${pingTime} ms`, 24, 72, 100);
   }
 }

--- a/src/objects/local-car-object.ts
+++ b/src/objects/local-car-object.ts
@@ -136,23 +136,26 @@ export class LocalCarObject extends CarObject {
     this.y = Math.max(3, Math.min(this.y, this.canvas.height - 60));
   }
 
-  protected renderDebugInformation(context: CanvasRenderingContext2D): void {
+  private renderDebugInformation(context: CanvasRenderingContext2D): void {
     DebugUtils.renderDebugText(
       context,
-      `Position: X(${Math.round(this.x)}) Y(${Math.round(this.y)})`,
       24,
       24,
-      160
+      `Position: X(${Math.round(this.x)}) Y(${Math.round(this.y)})`
     );
 
     DebugUtils.renderDebugText(
       context,
-      `Angle: ${((this.angle * 180) / Math.PI).toFixed(0)}°`,
       24,
       48,
-      80
+      `Angle: ${((this.angle * 180) / Math.PI).toFixed(0)}°`
     );
 
-    super.renderDebugInformation(context);
+    if (this.getPlayer()?.isHost()) {
+      DebugUtils.renderDebugText(context, 24, 72, "Host");
+    } else {
+      const pingTime = this.getPlayer()?.getPingTime() || 0;
+      DebugUtils.renderDebugText(context, 24, 72, `Ping: ${pingTime} ms`);
+    }
   }
 }

--- a/src/objects/local-car-object.ts
+++ b/src/objects/local-car-object.ts
@@ -3,6 +3,7 @@ import { ObjectType } from "../enums/object-type.js";
 import { CarObject } from "./car-object.js";
 import { JoystickObject } from "./joystick-object.js";
 import { GameKeyboard } from "../models/game-keyboard.js";
+import { DebugUtils } from "../utils/debug-utils.js";
 
 export class LocalCarObject extends CarObject {
   private readonly joystickObject: JoystickObject;
@@ -135,35 +136,23 @@ export class LocalCarObject extends CarObject {
     this.y = Math.max(3, Math.min(this.y, this.canvas.height - 60));
   }
 
-  private renderDebugInformation(context: CanvasRenderingContext2D): void {
-    this.renderDebugText(
+  protected renderDebugInformation(context: CanvasRenderingContext2D): void {
+    DebugUtils.renderDebugText(
       context,
       `Position: X(${Math.round(this.x)}) Y(${Math.round(this.y)})`,
       24,
       24,
       160
     );
-    this.renderDebugText(
+
+    DebugUtils.renderDebugText(
       context,
       `Angle: ${((this.angle * 180) / Math.PI).toFixed(0)}°`,
       24,
       48,
       80
     );
-  }
 
-  private renderDebugText(
-    context: CanvasRenderingContext2D,
-    text: string,
-    x: number,
-    y: number,
-    width: number
-  ): void {
-    context.fillStyle = "rgba(0, 0, 0, 0.6)";
-    context.fillRect(x, y, width, 20);
-    context.fillStyle = "#FFFF00";
-    context.font = "12px system-ui";
-    context.textAlign = "left";
-    context.fillText(text, x + 6, y + 14);
+    super.renderDebugInformation(context);
   }
 }

--- a/src/services/game-loop-service.ts
+++ b/src/services/game-loop-service.ts
@@ -155,6 +155,10 @@ export class GameLoopService {
       .getTimers()
       .forEach((timer) => timer.update(deltaTimeStamp));
 
+    this.gameController
+      .getIntervals()
+      .forEach((interval) => interval.update(deltaTimeStamp));
+
     this.gameController.getTransitionService().update(deltaTimeStamp);
 
     this.gameFrame.getCurrentScreen()?.update(deltaTimeStamp);

--- a/src/services/interval-service.ts
+++ b/src/services/interval-service.ts
@@ -1,0 +1,37 @@
+export class IntervalService {
+  private elapsedMilliseconds: number = 0;
+  private durationMilliseconds: number = 0;
+
+  private callback: () => void;
+
+  constructor(
+    durationSeconds: number,
+    callback: () => void,
+    private started: boolean = true
+  ) {
+    console.log(`${this.constructor.name} created`, this);
+
+    this.durationMilliseconds = durationSeconds * 1000;
+    this.callback = callback;
+  }
+
+  public start(): void {
+    this.started = true;
+  }
+
+  public restart(): void {
+    this.elapsedMilliseconds = 0;
+    this.start();
+  }
+
+  public update(deltaTimeStamp: DOMHighResTimeStamp): void {
+    if (this.started) {
+      this.elapsedMilliseconds += deltaTimeStamp;
+
+      if (this.elapsedMilliseconds >= this.durationMilliseconds) {
+        this.callback();
+        this.restart();
+      }
+    }
+  }
+}

--- a/src/services/webrtc-peer-service.ts
+++ b/src/services/webrtc-peer-service.ts
@@ -33,6 +33,7 @@ export class WebRTCPeerService {
   private joined: boolean = false;
 
   private pingStartTime: number | null = null;
+  private pingRoundTripTime: number = 0;
 
   constructor(private gameController: GameController, private token: string) {
     this.logger = new LoggerUtils(`WebRTC(${this.token})`);
@@ -128,6 +129,20 @@ export class WebRTCPeerService {
     });
   }
 
+  public mustPing(): boolean {
+    return this.pingStartTime === null;
+  }
+
+  public getPingTime(): number {
+    // Calculate ping round trip time
+    if (this.pingStartTime === null) {
+      return this.pingRoundTripTime;
+    }
+
+    // Current ping round trip time
+    return performance.now() - this.pingStartTime;
+  }
+
   public disconnectGracefully(): void {
     this.connectionState = ConnectionStateType.Disconnected;
     this.sendDisconnectMessage();
@@ -174,26 +189,6 @@ export class WebRTCPeerService {
 
     this.pingStartTime = performance.now();
     this.sendReliableOrderedMessage(arrayBuffer);
-  }
-
-  public handlePingRequest(): void {
-    const arrayBuffer = new ArrayBuffer(1);
-    const dataView = new DataView(arrayBuffer);
-    dataView.setInt8(0, WebRTCType.PingResponse);
-
-    this.sendReliableOrderedMessage(arrayBuffer);
-  }
-
-  public handlePingResponse(): void {
-    if (this.pingStartTime === null) {
-      return;
-    }
-
-    const pingEndTime = performance.now();
-    const rtt = pingEndTime - this.pingStartTime;
-    this.logger.info(`Round-trip time (RTT): ${rtt} ms`);
-
-    this.pingStartTime = null;
   }
 
   private initializeDataChannels(): void {
@@ -466,5 +461,22 @@ export class WebRTCPeerService {
     console.log("Received graceful disconnect message");
     this.connectionState = ConnectionStateType.Disconnected;
     this.disconnect();
+  }
+
+  private handlePingRequest(): void {
+    const arrayBuffer = new ArrayBuffer(1);
+    const dataView = new DataView(arrayBuffer);
+    dataView.setInt8(0, WebRTCType.PingResponse);
+
+    this.sendReliableOrderedMessage(arrayBuffer);
+  }
+
+  private handlePingResponse(): void {
+    if (this.pingStartTime === null) {
+      return;
+    }
+
+    this.pingRoundTripTime = performance.now() - this.pingStartTime;
+    this.pingStartTime = null;
   }
 }

--- a/src/utils/debug-utils.ts
+++ b/src/utils/debug-utils.ts
@@ -1,0 +1,16 @@
+export class DebugUtils {
+  public static renderDebugText(
+    context: CanvasRenderingContext2D,
+    text: string,
+    x: number,
+    y: number,
+    width: number
+  ): void {
+    context.fillStyle = "rgba(0, 0, 0, 0.6)";
+    context.fillRect(x, y, width, 20);
+    context.fillStyle = "#FFFF00";
+    context.font = "12px system-ui";
+    context.textAlign = "left";
+    context.fillText(text, x + 6, y + 14);
+  }
+}

--- a/src/utils/debug-utils.ts
+++ b/src/utils/debug-utils.ts
@@ -1,15 +1,21 @@
 export class DebugUtils {
   public static renderDebugText(
     context: CanvasRenderingContext2D,
-    text: string,
     x: number,
     y: number,
-    width: number
+    text: string
   ): void {
-    context.fillStyle = "rgba(0, 0, 0, 0.6)";
-    context.fillRect(x, y, width, 20);
-    context.fillStyle = "#FFFF00";
     context.font = "12px system-ui";
+
+    const textWidth = context.measureText(text).width;
+    const boxWidth = textWidth + 12; // Add margin to the calculated text width
+
+    // Render background box
+    context.fillStyle = "rgba(0, 0, 0, 0.6)";
+    context.fillRect(x, y, boxWidth, 20);
+
+    // Render text
+    context.fillStyle = "#FFFF00";
     context.textAlign = "left";
     context.fillText(text, x + 6, y + 14);
   }

--- a/src/utils/player-utils.ts
+++ b/src/utils/player-utils.ts
@@ -29,4 +29,16 @@ export class PlayerUtils {
 
     return animal;
   }
+
+  public static getColorByPingTime(ping: number): string {
+    if (ping > 100) {
+      return "orange";
+    }
+
+    if (ping > 50) {
+      return "yellow";
+    }
+
+    return "white";
+  }
 }

--- a/src/utils/player-utils.ts
+++ b/src/utils/player-utils.ts
@@ -30,15 +30,8 @@ export class PlayerUtils {
     return animal;
   }
 
-  public static getColorByPingTime(ping: number): string {
-    if (ping > 100) {
-      return "orange";
-    }
-
-    if (ping > 50) {
-      return "yellow";
-    }
-
+  public static getColorByPingTime(_ping: number): string {
+    // TODO: implement logic to return color based on ping time
     return "white";
   }
 }


### PR DESCRIPTION
Add ping/poll calculation time to WebRTC peer service and update matchmaking service to send ping requests.

* **Add constants to WebRTCType enum:**
  - Add `PingRequest` and `PingResponse` constants in `src/enums/webrtc-type.ts`.

* **Implement ping/poll calculation in WebRTC peer service:**
  - Add `sendPingRequest`, `handlePingRequest`, and `handlePingResponse` methods in `src/services/webrtc-peer-service.ts`.
  - Calculate round-trip time (RTT) for ping in `handlePingResponse`.
  - Update `handleMessage` method to handle `PingRequest` and `PingResponse`.

* **Update matchmaking service to send ping requests:**
  - Add a timer in the constructor to send ping requests to all connected peers every second if the player is the host in `src/services/matchmaking-service.ts`.
  - Implement `sendPingToAllPeers` method to send ping requests to all peers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/wheel-ball/pull/81?shareId=7fb598d7-9062-48b3-8668-ba85a16b61fe).